### PR TITLE
:sparkles: Add progress bar sounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,7 @@ dist/preload.js.map
 *.map
 
 ./.env.local
+
+# Ignore sounds folder - we won't back this up at all.
+# We will back up user preferences though.
+**/sounds/*

--- a/dist/main.js
+++ b/dist/main.js
@@ -344,6 +344,25 @@ handleInvoke("sounds-save", async (eventId, content) => {
         throw new main_process_errors_1.UnknownMainProcessError(`Failed to save sound for ${String(eventId)}`);
     }
 });
+// Read the saved .mp3 bytes for a given event, or null if not found.
+handleInvoke("sounds-read", async (eventId) => {
+    const name = SOUND_FILE_NAMES[eventId];
+    if (typeof name !== "string") {
+        throw new main_process_errors_1.UnknownMainProcessError("Invalid sound event id");
+    }
+    const dir = getSoundsDir();
+    const filePath = path_1.default.join(dir, name);
+    try {
+        if (fs_1.default.existsSync(filePath) === false) {
+            return null;
+        }
+        const buffer = fs_1.default.readFileSync(filePath);
+        return new Uint8Array(buffer);
+    }
+    catch (error) {
+        return null;
+    }
+});
 // Listener to handle saving progress bar data.
 // TODO: Group-up related handlers, as above.
 handleInvoke("save-data", async (data) => {

--- a/dist/preload.js
+++ b/dist/preload.js
@@ -33,6 +33,7 @@ const api = {
         };
     },
     saveData: (data) => invokeAndUnwrap("save-data", data),
+    savePartialData: (data) => invokeAndUnwrap("save-partial-data", data),
     loadData: () => invokeAndUnwrap("load-data"),
     savePassword: (password) => invokeAndUnwrap("save-password", password),
     getPassword: () => invokeAndUnwrap("get-password"),

--- a/dist/preload.js
+++ b/dist/preload.js
@@ -49,6 +49,8 @@ const api = {
     driveCancel: () => invokeAndUnwrap("drive-cancel"),
     /** Save a user-uploaded .mp3 sound under a canonical filename for the event. */
     saveSoundForEvent: (eventId, content) => invokeAndUnwrap("sounds-save", eventId, content),
+    /** Read raw .mp3 bytes for a given event from disk. */
+    readSoundForEvent: (eventId) => invokeAndUnwrap("sounds-read", eventId),
 };
 // Expose the API to the renderer process
 if (process.contextIsolated) {

--- a/dist/preload.js
+++ b/dist/preload.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const electron_1 = require("electron");
-// Helper: invoke IPC channel and unwrap the standard IpcResult envelope
+// Helper: invoke IPC channel and unwrap the standard IpcResult wrapper
 async function invokeAndUnwrap(channel, ...args) {
     const result = (await electron_1.ipcRenderer.invoke(channel, ...args));
     if (!result || typeof result !== "object" || !("ok" in result)) {
@@ -12,7 +12,7 @@ async function invokeAndUnwrap(channel, ...args) {
         // Some handlers may not return data (void)
         return result.data ?? undefined;
     }
-    // Error path: forward minimal error envelope { code, message, status }
+    // Error path: forward minimal error wrapper { code, message, status }
     throw result.error;
 }
 // Define the API we are exposing
@@ -46,6 +46,8 @@ const api = {
     driveSync: (params) => invokeAndUnwrap("drive-sync", params),
     driveRestore: (params) => invokeAndUnwrap("drive-restore", params),
     driveCancel: () => invokeAndUnwrap("drive-cancel"),
+    /** Save a user-uploaded .mp3 sound under a canonical filename for the event. */
+    saveSoundForEvent: (eventId, content) => invokeAndUnwrap("sounds-save", eventId, content),
 };
 // Expose the API to the renderer process
 if (process.contextIsolated) {

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/index.css",
+    "baseColor": "slate",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,13 +12,17 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@radix-ui/react-slider": "^1.3.6",
         "@types/react-modal": "^3.16.3",
+        "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.23.0",
+        "lucide-react": "^0.542.0",
         "react": "^19.1.0",
         "react-confetti": "^6.4.0",
         "react-dom": "^19.1.0",
         "react-modal": "^3.16.3",
+        "tailwind-merge": "^3.3.1",
         "vite-plugin-svgr": "^4.3.0"
       },
       "devDependencies": {
@@ -44,6 +48,7 @@
         "prettier": "^3.5.3",
         "tailwindcss": "^4.1.10",
         "ts-jest": "^29.4.0",
+        "tw-animate-css": "^1.3.7",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.34.1",
         "vite": "^6.3.5"
@@ -2095,6 +2100,248 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
+      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -3055,7 +3302,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -4333,6 +4580,18 @@
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -7887,6 +8146,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.542.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.542.0.tgz",
+      "integrity": "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -9769,6 +10037,16 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.10.tgz",
@@ -10056,6 +10334,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.7.tgz",
+      "integrity": "sha512-lvLb3hTIpB5oGsk8JmLoAjeCHV58nKa2zHYn8yWOoG5JJusH3bhJlF2DLAZ/5NmJ+jyH3ssiAx/2KmbhavJy/A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
     },
     "node_modules/tween-functions": {
       "version": "1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,13 +15,17 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@radix-ui/react-slider": "^1.3.6",
     "@types/react-modal": "^3.16.3",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.0",
+    "lucide-react": "^0.542.0",
     "react": "^19.1.0",
     "react-confetti": "^6.4.0",
     "react-dom": "^19.1.0",
     "react-modal": "^3.16.3",
+    "tailwind-merge": "^3.3.1",
     "vite-plugin-svgr": "^4.3.0"
   },
   "devDependencies": {
@@ -47,6 +51,7 @@
     "prettier": "^3.5.3",
     "tailwindcss": "^4.1.10",
     "ts-jest": "^29.4.0",
+    "tw-animate-css": "^1.3.7",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
     "vite": "^6.3.5"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,8 +24,8 @@ import type { ProgressBarData } from "../../types/shared";
 import type { SaveStatus } from "./types";
 import { SuccessModal } from "./components/SuccessModal";
 import { Button } from "./components/Button";
-import SyncModal from "./components/sync/SyncModal";
-import { CloudIcon } from "./components/Icons";
+import SettingsRoot from "./components/settings/SettingsRoot";
+import { useUiSounds } from "./hooks/useUiSounds";
 
 function App() {
   // Track save status for animations.
@@ -35,9 +35,6 @@ function App() {
   const [successModalBarId, setSuccessModalBarId] = useState<string | null>(
     null
   );
-
-  // State for settings menu.
-  const [settingsOpen, setSettingsOpen] = useState(false);
 
   const [bars, setBars] = useState<ProgressBarData[]>(() => {
     // Let's add a second bar for easier testing of drag-and-drop
@@ -102,7 +99,20 @@ function App() {
     }
   };
 
+  // UI sounds: only wire increment/decrement/complete for now (no button click)
+  const {
+    playProgressIncrementSound,
+    playProgressDecrementSound,
+    playProgressCompleteSound,
+  } = useUiSounds();
+
   const onIncrement = (id: string, sign: number = 1) => {
+    // Play increment/decrement sound immediately; precedence handled in manager
+    if (sign > 0) {
+      playProgressIncrementSound();
+    } else {
+      playProgressDecrementSound();
+    }
     setBars((prevBars) => {
       const updatedBars = prevBars.map((bar) =>
         bar.id === id
@@ -119,6 +129,8 @@ function App() {
       // Check if the bar was just completed
       const updatedBar = updatedBars.find((bar) => bar.id === id);
       if (updatedBar && updatedBar.current === updatedBar.max) {
+        // Play completion sound
+        playProgressCompleteSound();
         setSuccessModalBarId(id);
       }
 
@@ -241,22 +253,11 @@ function App() {
 
           <SaveButton status={saveStatus} onClick={handleSave} />
 
-          <button
-            onClick={() => setSettingsOpen(true)}
-            className="fixed bottom-6 right-6 w-12 h-12 text-slate-800 rounded-md bg-white flex items-center justify-center shadow-lg hover:bg-slate-800 hover:text-white transition-colors duration-200 border border-white"
-          >
-            <CloudIcon />
-          </button>
+          <SettingsRoot onDataRestored={handleRestoreData} currentBars={bars} />
         </main>
       </div>
 
-      {/* Modals */}
-      <SyncModal
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        onDataRestored={handleRestoreData}
-        currentBars={bars}
-      />
+      {/* Settings UI (drawer + modals) */}
 
       {editingBar && (
         <BarSettings

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -218,9 +218,9 @@ function App() {
             ];
 
             for (const eventId of eventIds) {
-              const dataUrl = savedPreferences.eventFiles?.[eventId];
-              if (typeof dataUrl === "string" && dataUrl.length > 0) {
-                soundManager.setSoundFileForEvent(eventId, dataUrl);
+              const fileRef = savedPreferences.eventFiles?.[eventId];
+              if (typeof fileRef === "string" && fileRef.length > 0) {
+                soundManager.setSoundFileForEvent(eventId, fileRef);
               }
             }
           }

--- a/frontend/src/components/Icons.tsx
+++ b/frontend/src/components/Icons.tsx
@@ -179,3 +179,61 @@ export function ErrorIcon() {
     </svg>
   );
 }
+
+export function VolumeIcon() {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11 5L6 9H3v6h3l5 4V5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M15.54 8.46a5 5 0 010 7.07M18.07 5.93a8.5 8.5 0 010 12.02"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** Simple Play (triangle) icon. */
+export function PlayIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M6 4l10 6-10 6V4z" fill="currentColor" />
+    </svg>
+  );
+}
+
+/** Simple Pause (two bars) icon. */
+export function PauseIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect x="5" y="4" width="3" height="12" fill="currentColor" />
+      <rect x="12" y="4" width="3" height="12" fill="currentColor" />
+    </svg>
+  );
+}

--- a/frontend/src/components/SuccessModal.tsx
+++ b/frontend/src/components/SuccessModal.tsx
@@ -2,6 +2,7 @@ import Modal from "react-modal";
 import type { ProgressBarData } from "../../../types/shared";
 import { Button } from "./Button";
 import ReactConfetti from "react-confetti";
+import { getSoundManager } from "../sound/soundManager";
 
 interface SuccessModalProps {
   barData: ProgressBarData;
@@ -14,6 +15,13 @@ export function SuccessModal({
   barData,
   onRequestClose,
 }: SuccessModalProps) {
+  const soundManager = getSoundManager();
+
+  const handleRequestClose = () => {
+    soundManager.stopAll();
+    onRequestClose();
+  };
+
   // TODO: Add custom uplifting dismiss messages + congratulations messages.
   // TODO: Add completion stats? Completed after x days. Created on...
   // TODO: Add the golden experience mission success soundbite (it was a minified, slightly muted version of the main theme).
@@ -24,6 +32,7 @@ export function SuccessModal({
         ariaHideApp={false}
         appElement={document.getElementById("root") as HTMLElement}
         shouldCloseOnOverlayClick={true}
+        onRequestClose={handleRequestClose}
         className="relative z-50 bg-black text-white rounded-2xl p-6 w-full max-w-md mx-auto mt-40 shadow-lg outline-none flex flex-col items-center space-y-2"
         overlayClassName="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 flex justify-center items-start"
       >
@@ -35,7 +44,7 @@ export function SuccessModal({
         <h4 className="font-thin">Placeholder for a short stats sentence</h4>
 
         <Button
-          onClick={onRequestClose}
+          onClick={handleRequestClose}
           tailwindColors="bg-lime-500 hover:bg-lime-600 text-black"
         >
           Let's goooooo!

--- a/frontend/src/components/settings/SettingsMenu.tsx
+++ b/frontend/src/components/settings/SettingsMenu.tsx
@@ -1,0 +1,93 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { CloseIcon, CloudIcon, VolumeIcon } from "../Icons";
+import React from "react";
+
+/**
+ * Left slide-out settings menu (drawer) with smooth animation.
+ * - Provides navigation to Cloud Sync and Sounds settings.
+ * - Closes when clicking the overlay or the close button.
+ */
+export interface SettingsMenuProps {
+  open: boolean;
+  onClose: () => void;
+  onOpenCloudSync: () => void;
+  onOpenSounds: () => void;
+}
+
+export default function SettingsMenu(props: SettingsMenuProps) {
+  const { open, onClose, onOpenCloudSync, onOpenSounds } = props;
+
+  return (
+    <AnimatePresence>
+      {open ? (
+        <>
+          {/* Overlay */}
+          <motion.div
+            className="fixed inset-0 bg-black/40 z-40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            onClick={() => onClose()}
+          />
+
+          {/* Drawer */}
+          <motion.aside
+            className="fixed left-0 top-0 bottom-0 w-80 max-w-[85vw] bg-gray-900 border-r border-white/10 z-50 shadow-2xl flex flex-col"
+            initial={{ x: -320 }}
+            animate={{ x: 0 }}
+            exit={{ x: -320 }}
+            transition={{ type: "tween", ease: "easeOut", duration: 0.22 }}
+          >
+            <div className="flex items-center justify-between p-4 border-b border-white/10">
+              <h2 className="text-lg font-semibold">Settings</h2>
+              <button
+                type="button"
+                onClick={() => onClose()}
+                className="titlebar-button hover:bg-red-500 border-2 border-white hover:border-red-500"
+              >
+                <CloseIcon />
+              </button>
+            </div>
+
+            <nav className="flex-1 p-2">
+              <ul className="space-y-1">
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onClose();
+                      onOpenCloudSync();
+                    }}
+                    className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/20 transition"
+                  >
+                    <CloudIcon />
+                    <span>Cloud Sync</span>
+                  </button>
+                </li>
+
+                <li>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onClose();
+                      onOpenSounds();
+                    }}
+                    className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/20 transition"
+                  >
+                    <VolumeIcon />
+                    <span>Sounds</span>
+                  </button>
+                </li>
+              </ul>
+            </nav>
+
+            <div className="p-3 text-xs text-gray-400 border-t border-white/10">
+              v1 Settings
+            </div>
+          </motion.aside>
+        </>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/settings/SettingsMenu.tsx
+++ b/frontend/src/components/settings/SettingsMenu.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { createPortal } from "react-dom";
 import { CloseIcon, CloudIcon, VolumeIcon } from "../Icons";
 import React from "react";
 
@@ -17,11 +18,11 @@ export interface SettingsMenuProps {
 export default function SettingsMenu(props: SettingsMenuProps) {
   const { open, onClose, onOpenCloudSync, onOpenSounds } = props;
 
-  return (
-    <AnimatePresence>
+  return createPortal(
+    <AnimatePresence initial={false}>
       {open ? (
         <>
-          {/* Overlay */}
+          {/* Overlay (raised z-index, full viewport) */}
           <motion.div
             className="fixed inset-0 bg-black/40 z-40"
             initial={{ opacity: 0 }}
@@ -31,9 +32,9 @@ export default function SettingsMenu(props: SettingsMenuProps) {
             onClick={() => onClose()}
           />
 
-          {/* Drawer */}
+          {/* Drawer (topmost) */}
           <motion.aside
-            className="fixed left-0 top-0 bottom-0 w-80 max-w-[85vw] bg-gray-900 border-r border-white/10 z-50 shadow-2xl flex flex-col"
+            className="fixed left-0 top-0 bottom-0 w-80 max-w-[85vw] bg-gray-900 text-white border-r border-white/10 z-50 shadow-2xl flex flex-col"
             initial={{ x: -320 }}
             animate={{ x: 0 }}
             exit={{ x: -320 }}
@@ -88,6 +89,7 @@ export default function SettingsMenu(props: SettingsMenuProps) {
           </motion.aside>
         </>
       ) : null}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/frontend/src/components/settings/SettingsRoot.tsx
+++ b/frontend/src/components/settings/SettingsRoot.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import SettingsMenu from "./SettingsMenu";
 import SyncModal from "../sync/SyncModal";
 import SoundsModal from "./SoundsModal";
@@ -21,15 +21,38 @@ export default function SettingsRoot(props: {
   const [syncOpen, setSyncOpen] = useState(false);
   const [soundsOpen, setSoundsOpen] = useState(false);
 
+  // Prevent background scroll and layout shift when any settings UI is open
+  useEffect(() => {
+    const anyOpen = menuOpen || syncOpen || soundsOpen;
+    const body = document.body;
+    const html = document.documentElement;
+    if (anyOpen) {
+      const scrollbarWidth = window.innerWidth - html.clientWidth;
+      body.style.overflow = "hidden";
+      if (scrollbarWidth > 0) {
+        body.style.paddingRight = `${scrollbarWidth}px`;
+      }
+    } else {
+      body.style.overflow = "";
+      body.style.paddingRight = "";
+    }
+    return () => {
+      body.style.overflow = "";
+      body.style.paddingRight = "";
+    };
+  }, [menuOpen, syncOpen, soundsOpen]);
+
   return (
     <>
       {/* Floating Settings button */}
-      <button
-        onClick={() => setMenuOpen(true)}
-        className="fixed bottom-6 right-6 w-12 h-12 text-slate-800 rounded-md bg-white flex items-center justify-center shadow-lg hover:bg-slate-800 hover:text-white transition-colors duration-200 border border-white"
-      >
-        <SettingsIcon />
-      </button>
+      {!menuOpen && !syncOpen && !soundsOpen && (
+        <button
+          onClick={() => setMenuOpen(true)}
+          className="fixed bottom-6 left-6 w-12 h-12 text-slate-800 rounded-md bg-white flex items-center justify-center shadow-lg hover:bg-slate-800 hover:text-white transition-colors duration-200 border border-white"
+        >
+          <SettingsIcon />
+        </button>
+      )}
 
       {/* Animated drawer */}
       <SettingsMenu

--- a/frontend/src/components/settings/SettingsRoot.tsx
+++ b/frontend/src/components/settings/SettingsRoot.tsx
@@ -72,11 +72,7 @@ export default function SettingsRoot(props: {
         currentBars={currentBars}
       />
 
-      <SoundsModal
-        open={soundsOpen}
-        onClose={() => setSoundsOpen(false)}
-        currentBars={currentBars}
-      />
+      <SoundsModal open={soundsOpen} onClose={() => setSoundsOpen(false)} />
     </>
   );
 }

--- a/frontend/src/components/settings/SettingsRoot.tsx
+++ b/frontend/src/components/settings/SettingsRoot.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import SettingsMenu from "./SettingsMenu";
+import SyncModal from "../sync/SyncModal";
+import SoundsModal from "./SoundsModal";
+import { SettingsIcon } from "../Icons";
+import type { ProgressBarData } from "../../../../types/shared";
+
+/**
+ * SettingsRoot centralizes Settings UI:
+ * - Floating gear button to open the SettingsMenu (left drawer)
+ * - SettingsMenu navigation to Cloud Sync and Sounds
+ * - Renders Cloud Sync modal here, not in App.tsx
+ */
+export default function SettingsRoot(props: {
+  onDataRestored: (restored: ProgressBarData[]) => void;
+  currentBars: ProgressBarData[];
+}) {
+  const { onDataRestored, currentBars } = props;
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [syncOpen, setSyncOpen] = useState(false);
+  const [soundsOpen, setSoundsOpen] = useState(false);
+
+  return (
+    <>
+      {/* Floating Settings button */}
+      <button
+        onClick={() => setMenuOpen(true)}
+        className="fixed bottom-6 right-6 w-12 h-12 text-slate-800 rounded-md bg-white flex items-center justify-center shadow-lg hover:bg-slate-800 hover:text-white transition-colors duration-200 border border-white"
+      >
+        <SettingsIcon />
+      </button>
+
+      {/* Animated drawer */}
+      <SettingsMenu
+        open={menuOpen}
+        onClose={() => setMenuOpen(false)}
+        onOpenCloudSync={() => setSyncOpen(true)}
+        onOpenSounds={() => {
+          setSoundsOpen(true);
+        }}
+      />
+
+      {/* Cloud Sync modal now lives under Settings */}
+      <SyncModal
+        open={syncOpen}
+        onClose={() => setSyncOpen(false)}
+        onDataRestored={onDataRestored}
+        currentBars={currentBars}
+      />
+
+      <SoundsModal
+        open={soundsOpen}
+        onClose={() => setSoundsOpen(false)}
+        currentBars={currentBars}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/settings/SoundsModal.tsx
+++ b/frontend/src/components/settings/SoundsModal.tsx
@@ -5,8 +5,7 @@ import {
   canonicalFilenameForEvent,
   readFileAsDataUrl,
 } from "../../sound/soundManager";
-import type { ProgressBarData } from "../../../../types/shared";
-import type { SoundEventId } from "../../sound/soundEvents";
+import type { ProgressBarData, SoundEventId } from "../../../../types/shared";
 
 // TODO
 /**

--- a/frontend/src/components/settings/SoundsModal.tsx
+++ b/frontend/src/components/settings/SoundsModal.tsx
@@ -1,0 +1,438 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { CloseIcon, PlayIcon, PauseIcon } from "../Icons";
+import {
+  getSoundManager,
+  canonicalFilenameForEvent,
+  readFileAsDataUrl,
+} from "../../sound/soundManager";
+import type { ProgressBarData } from "../../../../types/shared";
+import type { SoundEventId } from "../../sound/soundEvents";
+
+// TODO
+/**
+ * Things to fix:
+ * - progress bar plays for every sound, even though I play a single sound;
+ * - master volume changer doesn't work;
+ * - master volume changer should work while the sound is playing;
+ * - clicking let's go doesn't stop the success sound;
+ */
+
+/** UI metadata for supported sound events. */
+const EVENT_ITEMS: Array<{ id: SoundEventId; label: string }> = [
+  { id: "progressIncrement", label: "Increment" },
+  { id: "progressDecrement", label: "Decrement" },
+  { id: "progressComplete", label: "Complete" },
+];
+
+/** Default preferences for modal state when nothing is saved yet. */
+const DEFAULT_MODAL_PREFS = {
+  masterVolume: 0.6,
+  muteAll: false,
+  eventFiles: {
+    ["progressIncrement"]: "",
+    ["progressDecrement"]: "",
+    ["progressComplete"]: "",
+  } as Record<SoundEventId, string>,
+};
+
+export interface SoundsModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Bars must be provided when saving sounds, as main currently overwrites bars if omitted. */
+  currentBars: ProgressBarData[];
+}
+
+/**
+ * SoundsModal lets users upload per-event .mp3 files and preview them.
+ * - Uploaded bytes are saved via IPC under canonical filenames.
+ * - Data URLs are persisted in AppData.sounds.preferences.eventFiles for sandbox-safe playback and sync.
+ * - Preview uses an internal Audio element with a mini progress bar.
+ */
+export default function SoundsModal(props: SoundsModalProps) {
+  const { open, onClose, currentBars } = props;
+
+  const soundManager = useMemo(() => {
+    return getSoundManager();
+  }, []);
+
+  const [preferences, setPreferences] = useState(DEFAULT_MODAL_PREFS);
+  const [busy, setBusy] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Preview state (single audio element for simplicity)
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [playingEvent, setPlayingEvent] = useState<SoundEventId | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  /** Load existing preferences when opening the modal. */
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadPrefs() {
+      try {
+        const data = await window.api.loadData();
+        const existing = data?.sounds?.preferences;
+
+        if (isMounted) {
+          if (existing && typeof existing === "object") {
+            const next = {
+              masterVolume:
+                typeof existing.masterVolume === "number"
+                  ? existing.masterVolume
+                  : DEFAULT_MODAL_PREFS.masterVolume,
+              muteAll: existing.muteAll === true,
+              eventFiles: {
+                ...DEFAULT_MODAL_PREFS.eventFiles,
+                ...(existing.eventFiles as Record<SoundEventId, string>),
+              },
+            } as typeof DEFAULT_MODAL_PREFS;
+
+            setPreferences(next);
+
+            // Seed SoundManager so app playback reflects current saved choices.
+            try {
+              soundManager.setMasterVolume(next.masterVolume);
+              for (const item of EVENT_ITEMS) {
+                const dataUrl = next.eventFiles[item.id];
+                if (typeof dataUrl === "string" && dataUrl.length > 0) {
+                  soundManager.setSoundFileForEvent(item.id, dataUrl);
+                }
+              }
+            } catch {
+              // Ignore manager errors
+            }
+          } else {
+            setPreferences(DEFAULT_MODAL_PREFS);
+          }
+        }
+      } catch {
+        if (isMounted) {
+          setPreferences(DEFAULT_MODAL_PREFS);
+        }
+      }
+    }
+
+    if (open) {
+      loadPrefs();
+    }
+
+    return () => {
+      isMounted = false;
+    };
+  }, [open, soundManager]);
+
+  /** Clean up preview audio when modal closes. */
+  useEffect(() => {
+    if (open === false) {
+      stopPreview();
+    }
+  }, [open]);
+
+  /** Attach timeupdate listeners for preview updates. */
+  useEffect(() => {
+    const audioElement = audioRef.current;
+
+    if (!audioElement) {
+      return;
+    }
+
+    const handleTime = () => {
+      if (audioElement.duration && Number.isFinite(audioElement.duration)) {
+        setDuration(audioElement.duration);
+        setProgress(audioElement.currentTime);
+      }
+    };
+
+    const handleEnd = () => {
+      setPlayingEvent(null);
+    };
+
+    audioElement.addEventListener("timeupdate", handleTime);
+    audioElement.addEventListener("ended", handleEnd);
+    audioElement.addEventListener("error", handleEnd);
+
+    return () => {
+      audioElement.removeEventListener("timeupdate", handleTime);
+      audioElement.removeEventListener("ended", handleEnd);
+      audioElement.removeEventListener("error", handleEnd);
+    };
+  }, [audioRef.current]);
+
+  /** Handle file upload for a given event. */
+  const handleFileChange = async (
+    eventId: SoundEventId,
+    file: File | null
+  ): Promise<void> => {
+    setErrorMessage(null);
+
+    if (file === null) {
+      return;
+    }
+
+    if (
+      file.type !== "audio/mpeg" &&
+      file.name.toLowerCase().endsWith(".mp3") === false
+    ) {
+      setErrorMessage("Only .mp3 files are supported.");
+      return;
+    }
+
+    try {
+      setBusy(true);
+
+      // Prepare bytes and data URL
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      const dataUrl = await readFileAsDataUrl(file);
+
+      // Save to disk under canonical filename via IPC
+      await window.api.saveSoundForEvent(eventId, bytes);
+
+      // Upload raw .mp3 to Google Drive (unencrypted), using canonical filename
+      try {
+        const canonicalFileName = canonicalFilenameForEvent(eventId);
+        await window.api.driveSync({
+          fileName: canonicalFileName,
+          content: bytes,
+          contentType: "audio/mpeg",
+        });
+      } catch {
+        // Ignore Drive sync errors; local save and preferences still succeed
+      }
+
+      // Update local prefs and SoundManager immediately
+      const nextEventFiles: Record<SoundEventId, string> = {
+        ...preferences.eventFiles,
+        [eventId]: dataUrl,
+      };
+
+      setPreferences((prev) => ({ ...prev, eventFiles: nextEventFiles }));
+
+      soundManager.setSoundFileForEvent(eventId, dataUrl);
+
+      // Persist to app data with current bars (main overwrites bars if omitted)
+      await window.api.saveData({
+        bars: currentBars,
+        sounds: { preferences: { ...preferences, eventFiles: nextEventFiles } },
+      });
+    } catch (error) {
+      console.error("Failed to save sound:", error);
+      setErrorMessage("Failed to save the selected sound. Please try again.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /** Toggle preview for a given event. */
+  const togglePreview = (eventId: SoundEventId): void => {
+    const sourceUrl = preferences.eventFiles[eventId];
+
+    if (typeof sourceUrl !== "string" || sourceUrl.length === 0) {
+      return;
+    }
+
+    if (playingEvent === eventId) {
+      pausePreview();
+    } else {
+      playPreview(sourceUrl, eventId);
+    }
+  };
+
+  /** Start previewing a given data URL. */
+  const playPreview = (dataUrl: string, eventId: SoundEventId): void => {
+    stopPreview();
+
+    try {
+      const audioElement = new Audio(dataUrl);
+      audioElement.preload = "auto";
+      audioElement.volume = 1.0; // Preview at full; respects master volume during actual playback
+      audioRef.current = audioElement;
+      setPlayingEvent(eventId);
+      setProgress(0);
+      setDuration(0);
+
+      void audioElement.play().catch(() => {
+        // Ignore autoplay restrictions inside modal
+      });
+    } catch {
+      // Ignore invalid URL errors
+    }
+  };
+
+  /** Pause current preview, if any. */
+  const pausePreview = (): void => {
+    const audioElement = audioRef.current;
+    if (audioElement) {
+      try {
+        audioElement.pause();
+      } catch {
+        // Ignore errors
+      }
+    }
+    setPlayingEvent(null);
+  };
+
+  /** Stop and reset preview, clearing element. */
+  const stopPreview = (): void => {
+    const audioElement = audioRef.current;
+    if (audioElement) {
+      try {
+        audioElement.pause();
+        audioElement.currentTime = 0;
+      } catch {
+        // Ignore errors
+      }
+    }
+    audioRef.current = null;
+    setPlayingEvent(null);
+    setProgress(0);
+    setDuration(0);
+  };
+
+  /** Handle master volume slider change and persist. */
+  const handleMasterVolumeChange = async (
+    changeEvent: React.ChangeEvent<HTMLInputElement>
+  ): Promise<void> => {
+    const rawValue = parseFloat(changeEvent.target.value);
+    let nextVolume = Number.isFinite(rawValue) ? rawValue : 0;
+    if (nextVolume < 0) {
+      nextVolume = 0;
+    } else if (nextVolume > 1) {
+      nextVolume = 1;
+    }
+
+    setPreferences((prev) => ({ ...prev, masterVolume: nextVolume }));
+    soundManager.setMasterVolume(nextVolume);
+
+    try {
+      await window.api.saveData({
+        bars: currentBars,
+        sounds: {
+          preferences: { ...preferences, masterVolume: nextVolume },
+        },
+      });
+    } catch {
+      // Ignore persistence errors for volume change
+    }
+  };
+
+  return open ? (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/40"
+      onClick={() => onClose()}
+    >
+      <div
+        className="bg-gray-800 rounded-lg p-6 w-full max-w-xl"
+        onClick={(mouseEvent) => mouseEvent.stopPropagation()}
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">Sounds</h2>
+          <button
+            type="button"
+            onClick={() => onClose()}
+            className="titlebar-button hover:bg-red-500 border-2 border-white hover:border-red-500"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+
+        {errorMessage ? (
+          <div className="mb-4 bg-red-900/40 border border-red-500 text-red-300 p-3 rounded-md">
+            {errorMessage}
+          </div>
+        ) : null}
+
+        <div className="space-y-4">
+          <div className="border border-white/10 rounded-md p-3">
+            <label className="block text-sm font-medium mb-2">
+              Master volume
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={preferences.masterVolume}
+                onChange={handleMasterVolumeChange}
+                className="w-full"
+              />
+              <span className="text-sm tabular-nums">
+                {Math.round(preferences.masterVolume * 100)}%
+              </span>
+            </div>
+          </div>
+
+          {EVENT_ITEMS.map((item) => {
+            const dataUrl = preferences.eventFiles[item.id];
+            const isPlaying = playingEvent === item.id;
+            const percent =
+              duration > 0 ? Math.min(100, (progress / duration) * 100) : 0;
+            const inputId = `file-${item.id}`;
+
+            return (
+              <div
+                key={item.id}
+                className="border border-white/10 rounded-md p-3"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <div className="font-medium">{item.label}</div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => togglePreview(item.id)}
+                      disabled={
+                        typeof dataUrl !== "string" ||
+                        dataUrl.length === 0 ||
+                        busy
+                      }
+                      className="px-2 py-1 rounded-md bg-white/10 hover:bg-white/20 disabled:opacity-50 flex items-center gap-1"
+                    >
+                      {isPlaying ? <PauseIcon /> : <PlayIcon />}
+                      <span className="text-sm">
+                        {isPlaying ? "Pause" : "Play"}
+                      </span>
+                    </button>
+
+                    <label
+                      htmlFor={inputId}
+                      className="px-3 py-1 rounded-md bg-blue-500 hover:bg-blue-600 text-black cursor-pointer"
+                    >
+                      Upload .mp3
+                    </label>
+                    <input
+                      id={inputId}
+                      type="file"
+                      accept="audio/mpeg,.mp3"
+                      className="hidden"
+                      onChange={(changeEvent) =>
+                        handleFileChange(
+                          item.id,
+                          changeEvent.target.files?.[0] ?? null
+                        )
+                      }
+                      disabled={busy}
+                    />
+                  </div>
+                </div>
+
+                <div className="h-1 w-full bg-white/10 rounded">
+                  <div
+                    className="h-1 bg-lime-500 rounded"
+                    style={{ width: `${percent}%` }}
+                  />
+                </div>
+
+                <div className="mt-1 text-xs text-gray-400">
+                  {typeof dataUrl === "string" && dataUrl.length > 0
+                    ? "Custom sound selected"
+                    : "No sound selected"}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  ) : null;
+}

--- a/frontend/src/components/settings/SoundsModal.tsx
+++ b/frontend/src/components/settings/SoundsModal.tsx
@@ -9,6 +9,9 @@ import type { SoundEventId } from "../../../../types/shared";
 import { Slider } from "../ui/slider";
 import { createPortal } from "react-dom";
 
+// TODO: Obviously, fix theming.
+// TODO: Need a better way to signal visually whether a sound has been uploaded or not.
+
 /** UI metadata for supported sound events. */
 const EVENT_ITEMS: Array<{ id: SoundEventId; label: string }> = [
   { id: "progressIncrement", label: "Increment" },

--- a/frontend/src/components/settings/SoundsModal.tsx
+++ b/frontend/src/components/settings/SoundsModal.tsx
@@ -14,6 +14,7 @@ import type { ProgressBarData, SoundEventId } from "../../../../types/shared";
  * - master volume changer doesn't work;
  * - master volume changer should work while the sound is playing;
  * - clicking let's go doesn't stop the success sound;
+ * - Passing the progress bar data into this function should not be necessary.
  */
 
 /** UI metadata for supported sound events. */
@@ -366,7 +367,9 @@ export default function SoundsModal(props: SoundsModalProps) {
             const dataUrl = preferences.eventFiles[item.id];
             const isPlaying = playingEvent === item.id;
             const percent =
-              duration > 0 ? Math.min(100, (progress / duration) * 100) : 0;
+              isPlaying && duration > 0
+                ? Math.min(100, (progress / duration) * 100)
+                : 0;
             const inputId = `file-${item.id}`;
 
             return (

--- a/frontend/src/components/settings/SoundsModal.tsx
+++ b/frontend/src/components/settings/SoundsModal.tsx
@@ -5,16 +5,9 @@ import {
   canonicalFilenameForEvent,
   readFileAsDataUrl,
 } from "../../sound/soundManager";
-import type { ProgressBarData, SoundEventId } from "../../../../types/shared";
+import type { SoundEventId } from "../../../../types/shared";
 import { Slider } from "../ui/slider";
 import { createPortal } from "react-dom";
-
-// TODO
-/**
- * Things to fix:
- * - clicking let's go doesn't stop the success sound;
- * - Passing the progress bar data into this function should not be necessary.
- */
 
 /** UI metadata for supported sound events. */
 const EVENT_ITEMS: Array<{ id: SoundEventId; label: string }> = [
@@ -37,8 +30,6 @@ const DEFAULT_MODAL_PREFS = {
 export interface SoundsModalProps {
   open: boolean;
   onClose: () => void;
-  /** Bars must be provided when saving sounds, as main currently overwrites bars if omitted. */
-  currentBars: ProgressBarData[];
 }
 
 /**
@@ -48,7 +39,7 @@ export interface SoundsModalProps {
  * - Preview uses an internal Audio element with a mini progress bar.
  */
 export default function SoundsModal(props: SoundsModalProps) {
-  const { open, onClose, currentBars } = props;
+  const { open, onClose } = props;
 
   const soundManager = useMemo(() => {
     return getSoundManager();
@@ -210,8 +201,7 @@ export default function SoundsModal(props: SoundsModalProps) {
       soundManager.setSoundFileForEvent(eventId, dataUrl);
 
       // Persist to app data with current bars (main overwrites bars if omitted)
-      await window.api.saveData({
-        bars: currentBars,
+      await window.api.savePartialData({
         sounds: { preferences: { ...preferences, eventFiles: nextEventFiles } },
       });
     } catch (error) {
@@ -335,8 +325,7 @@ export default function SoundsModal(props: SoundsModalProps) {
     }
 
     try {
-      await window.api.saveData({
-        bars: currentBars,
+      await window.api.savePartialData({
         sounds: {
           preferences: { ...preferences, masterVolume: nextVolume },
         },

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -1,0 +1,61 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+        />
+      ))}
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/frontend/src/hooks/useGoogleDriveSync.ts
+++ b/frontend/src/hooks/useGoogleDriveSync.ts
@@ -1,7 +1,18 @@
 import { useEffect, useState } from "react";
-import type { ProgressBarData, VersionedAppData } from "../../../types/shared";
+import type {
+  ProgressBarData,
+  VersionedAppData,
+  SoundEventId,
+} from "../../../types/shared";
 import { createVersionedData } from "../utils/dataMigration";
 import { decryptData, encryptData } from "../utils/crypto";
+import {
+  canonicalFilenameForEvent,
+  dataUrlToUint8Array,
+  bytesToDataUrl,
+  getSoundManager,
+} from "../sound/soundManager";
+import { SOUND_EVENT_IDS } from "../sound/soundEvents";
 
 const DRIVE_FILE_NAME = "goal-tracker.appdata.enc" as const;
 
@@ -48,7 +59,12 @@ export function useGoogleDriveSync() {
       throw new Error("Missing encryption password");
     }
 
-    const versionedData = createVersionedData(bars);
+    // Include sounds preferences snapshot (if any) in encrypted payload.
+    const savedAppData = await window.api.loadData();
+    const versionedBase = createVersionedData(bars);
+    const versionedData: VersionedAppData = savedAppData?.sounds
+      ? { ...versionedBase, sounds: savedAppData.sounds }
+      : versionedBase;
     const jsonData = JSON.stringify(versionedData);
     const encryptedData = await encryptData(jsonData, password);
     const bytesData = new TextEncoder().encode(encryptedData);
@@ -61,8 +77,33 @@ export function useGoogleDriveSync() {
 
     setLastSynced(versionedData.lastSynced);
 
-    // Persist lastSynced alongside bars in local AppData.
-    await window.api.saveData({ bars, lastSynced: versionedData.lastSynced });
+    // Persist lastSynced alongside bars in local AppData (preserve sounds locally).
+    await window.api.savePartialData({
+      bars,
+      lastSynced: versionedData.lastSynced,
+    });
+
+    // Also push raw .mp3s for each event to Drive (unencrypted, canonical filenames).
+    try {
+      const preferences = savedAppData?.sounds?.preferences;
+      if (preferences && typeof preferences === "object") {
+        for (const eventId of SOUND_EVENT_IDS as SoundEventId[]) {
+          const dataUrl = preferences.eventFiles?.[eventId];
+          if (typeof dataUrl === "string" && dataUrl.length > 0) {
+            const mp3Bytes = dataUrlToUint8Array(dataUrl);
+            if (mp3Bytes && mp3Bytes.length > 0) {
+              await window.api.driveSync({
+                fileName: canonicalFilenameForEvent(eventId),
+                content: mp3Bytes,
+                contentType: "audio/mpeg",
+              });
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore Drive .mp3 upload failures; encrypted appdata already synced.
+    }
   };
 
   const restoreFromDrive = async (
@@ -81,11 +122,68 @@ export function useGoogleDriveSync() {
 
     setLastSynced(versionedData.lastSynced);
 
-    // Persist restored bars and lastSynced to local AppData.
-    await window.api.saveData({
+    // Attempt to restore raw .mp3s from Drive into local userData/sounds.
+    const restoredDataUrls: Partial<Record<SoundEventId, string>> = {};
+
+    for (const eventId of SOUND_EVENT_IDS as SoundEventId[]) {
+      try {
+        const fileName = canonicalFilenameForEvent(eventId);
+        const mp3Bytes = await window.api.driveRestore({ fileName });
+        if (mp3Bytes && mp3Bytes.length > 0) {
+          // Save bytes locally under canonical filename for the event.
+          await window.api.saveSoundForEvent(eventId, mp3Bytes);
+          // Build a data URL so we can seed preferences if needed.
+          restoredDataUrls[eventId] = bytesToDataUrl(mp3Bytes, "audio/mpeg");
+        }
+      } catch {
+        // Ignore if not found; not all events need to have a sound uploaded.
+      }
+    }
+
+    // Determine final preferences to persist: prefer encrypted snapshot, fallback to rebuilt from restored bytes.
+    const encryptedPrefs = versionedData.sounds?.preferences;
+    const nextPreferences = encryptedPrefs
+      ? encryptedPrefs
+      : {
+          masterVolume: 0.6,
+          muteAll: false,
+          eventFiles: ((): Record<SoundEventId, string> => {
+            const map: Partial<Record<SoundEventId, string>> = {};
+            for (const eventId of SOUND_EVENT_IDS as SoundEventId[]) {
+              map[eventId] = restoredDataUrls[eventId] ?? "";
+            }
+            return map as Record<SoundEventId, string>;
+          })(),
+        };
+
+    // Persist restored bars/lastSynced and sounds preferences.
+    await window.api.savePartialData({
       bars: versionedData.bars,
       lastSynced: versionedData.lastSynced,
+      sounds: nextPreferences ? { preferences: nextPreferences } : undefined,
     });
+
+    // Update SoundManager immediately so sounds work without reopening modal.
+    try {
+      const soundManager = getSoundManager();
+      if (nextPreferences) {
+        if (typeof nextPreferences.masterVolume === "number") {
+          soundManager.setMasterVolume(nextPreferences.masterVolume);
+        }
+        if (typeof nextPreferences.muteAll === "boolean") {
+          soundManager.setMuteAll(nextPreferences.muteAll);
+        }
+        for (const eventId of SOUND_EVENT_IDS as SoundEventId[]) {
+          const dataUrl = nextPreferences.eventFiles?.[eventId];
+          if (typeof dataUrl === "string" && dataUrl.length > 0) {
+            soundManager.setSoundFileForEvent(eventId, dataUrl);
+          }
+        }
+      }
+    } catch {
+      // Ignore manager errors
+    }
+
     return versionedData.bars;
   };
 
@@ -96,7 +194,10 @@ export function useGoogleDriveSync() {
         const barsToPersist = Array.isArray(savedAppData?.bars)
           ? savedAppData!.bars
           : [];
-        await window.api.saveData({ bars: barsToPersist, lastSynced: null });
+        await window.api.savePartialData({
+          bars: barsToPersist,
+          lastSynced: null,
+        });
       } finally {
         setLastSynced(null);
       }

--- a/frontend/src/hooks/useUiSounds.ts
+++ b/frontend/src/hooks/useUiSounds.ts
@@ -1,0 +1,54 @@
+import { useMemo } from "react";
+import { getSoundManager } from "../sound/soundManager";
+
+/**
+ * React hook exposing UI sound helpers backed by SoundManager.
+ * Notes:
+ * - Precedence: when multiple sounds are triggered quickly, the newest sound
+ *   interrupts the previous (handled by SoundManager).
+ * - Provides simple play helpers per event and volume/mute setters.
+ */
+export function useUiSounds() {
+  const soundManager = useMemo(() => {
+    return getSoundManager();
+  }, []);
+
+  /** Play the generic button click sound. */
+  const playButtonClickSound = (): void => {
+    soundManager.playEventSound("buttonClick");
+  };
+
+  /** Play the progress increment sound. */
+  const playProgressIncrementSound = (): void => {
+    soundManager.playEventSound("progressIncrement");
+  };
+
+  /** Play the progress decrement sound. */
+  const playProgressDecrementSound = (): void => {
+    soundManager.playEventSound("progressDecrement");
+  };
+
+  /** Play the progress complete sound. */
+  const playProgressCompleteSound = (): void => {
+    soundManager.playEventSound("progressComplete");
+  };
+
+  /** Set the master output volume (0..1 inclusive). */
+  const setMasterVolume = (masterVolume: number): void => {
+    soundManager.setMasterVolume(masterVolume);
+  };
+
+  /** Mute or unmute all sounds. */
+  const setMuteAll = (muteAll: boolean): void => {
+    soundManager.setMuteAll(muteAll);
+  };
+
+  return {
+    playButtonClickSound,
+    playProgressIncrementSound,
+    playProgressDecrementSound,
+    playProgressCompleteSound,
+    setMasterVolume,
+    setMuteAll,
+  } as const;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,7 @@
 @import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
 
 @layer components {
   .titlebar {
@@ -56,5 +59,121 @@
 
   ::-webkit-scrollbar-thumb:hover {
     background: #475569; /* slate-600 */
+  }
+}
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.129 0.042 264.695);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.129 0.042 264.695);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.129 0.042 264.695);
+  --primary: oklch(0.208 0.042 265.755);
+  --primary-foreground: oklch(0.984 0.003 247.858);
+  --secondary: oklch(0.968 0.007 247.896);
+  --secondary-foreground: oklch(0.208 0.042 265.755);
+  --muted: oklch(0.968 0.007 247.896);
+  --muted-foreground: oklch(0.554 0.046 257.417);
+  --accent: oklch(0.968 0.007 247.896);
+  --accent-foreground: oklch(0.208 0.042 265.755);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.929 0.013 255.508);
+  --input: oklch(0.929 0.013 255.508);
+  --ring: oklch(0.704 0.04 256.788);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.984 0.003 247.858);
+  --sidebar-foreground: oklch(0.129 0.042 264.695);
+  --sidebar-primary: oklch(0.208 0.042 265.755);
+  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-accent: oklch(0.968 0.007 247.896);
+  --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
+  --sidebar-border: oklch(0.929 0.013 255.508);
+  --sidebar-ring: oklch(0.704 0.04 256.788);
+}
+
+.dark {
+  --background: oklch(0.129 0.042 264.695);
+  --foreground: oklch(0.984 0.003 247.858);
+  --card: oklch(0.208 0.042 265.755);
+  --card-foreground: oklch(0.984 0.003 247.858);
+  --popover: oklch(0.208 0.042 265.755);
+  --popover-foreground: oklch(0.984 0.003 247.858);
+  --primary: oklch(0.929 0.013 255.508);
+  --primary-foreground: oklch(0.208 0.042 265.755);
+  --secondary: oklch(0.279 0.041 260.031);
+  --secondary-foreground: oklch(0.984 0.003 247.858);
+  --muted: oklch(0.279 0.041 260.031);
+  --muted-foreground: oklch(0.704 0.04 256.788);
+  --accent: oklch(0.279 0.041 260.031);
+  --accent-foreground: oklch(0.984 0.003 247.858);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.551 0.027 264.364);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.208 0.042 265.755);
+  --sidebar-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-accent: oklch(0.279 0.041 260.031);
+  --sidebar-accent-foreground: oklch(0.984 0.003 247.858);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.551 0.027 264.364);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -15,7 +15,7 @@
   }
 
   .app-container {
-    @apply h-screen flex flex-col pt-8 text-white;
+    @apply h-screen flex flex-col pt-8 text-white bg-slate-900;
   }
 
   .content-container {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/frontend/src/sound/soundEvents.ts
+++ b/frontend/src/sound/soundEvents.ts
@@ -4,6 +4,8 @@
  * - No bundled defaults. If folder/file is missing, sound simply won't play.
  */
 
+// TODO: Confusing file name + remove extra comments.
+
 import type { SoundEventId } from "../../../types/shared";
 
 export interface SoundPreferences {
@@ -27,9 +29,27 @@ export const DEFAULT_MASTER_VOLUME = 0.6;
 export const DEFAULT_MUTE_ALL = false;
 export const DEFAULT_SOUNDS_FOLDER = "/home/sounds";
 
+/**
+ * Canonical list of sound event IDs. Derived from DEFAULT_SOUND_FILES keys so it scales
+ * automatically as new events are added.
+ */
+export const SOUND_EVENT_IDS: ReadonlyArray<SoundEventId> = Object.freeze(
+  Object.keys(DEFAULT_SOUND_FILES) as SoundEventId[]
+);
+
 export const DEFAULT_SOUND_PREFERENCES: SoundPreferences = {
   masterVolume: DEFAULT_MASTER_VOLUME,
   muteAll: DEFAULT_MUTE_ALL,
   soundsFolder: DEFAULT_SOUNDS_FOLDER,
-  eventFiles: { ...DEFAULT_SOUND_FILES },
+  // Default to empty strings; renderer uses data URLs for playback.
+  eventFiles: ((): Record<SoundEventId, string> => {
+    const map: Record<SoundEventId, string> = {} as Record<
+      SoundEventId,
+      string
+    >;
+    for (const id of SOUND_EVENT_IDS) {
+      map[id as SoundEventId] = "";
+    }
+    return map;
+  })(),
 };

--- a/frontend/src/sound/soundEvents.ts
+++ b/frontend/src/sound/soundEvents.ts
@@ -1,0 +1,41 @@
+/**
+ * UI sound events and preferences.
+ * - Linux-focused: user selects an absolute sounds folder (default: /home/sounds).
+ * - No bundled defaults. If folder/file is missing, sound simply won't play.
+ *
+ */
+
+export type SoundEventId =
+  | "buttonClick"
+  | "progressIncrement"
+  | "progressDecrement"
+  | "progressComplete";
+
+export interface SoundPreferences {
+  /** Master volume 0..1 */
+  masterVolume: number;
+  /** Mute all sounds */
+  muteAll: boolean;
+  /** Absolute path to the sounds folder (Linux default: /home/sounds) */
+  soundsFolder: string;
+  /** Mapping of event id -> file reference (basename or absolute path or full URL) */
+  eventFiles: Record<SoundEventId, string>;
+}
+
+export const DEFAULT_SOUND_FILES: Record<SoundEventId, string> = {
+  buttonClick: "ui_click.mp3",
+  progressIncrement: "ui_increment.mp3",
+  progressDecrement: "ui_decrement.mp3",
+  progressComplete: "ui_complete.mp3",
+};
+
+export const DEFAULT_MASTER_VOLUME = 0.6;
+export const DEFAULT_MUTE_ALL = false;
+export const DEFAULT_SOUNDS_FOLDER = "/home/sounds";
+
+export const DEFAULT_SOUND_PREFERENCES: SoundPreferences = {
+  masterVolume: DEFAULT_MASTER_VOLUME,
+  muteAll: DEFAULT_MUTE_ALL,
+  soundsFolder: DEFAULT_SOUNDS_FOLDER,
+  eventFiles: { ...DEFAULT_SOUND_FILES },
+};

--- a/frontend/src/sound/soundEvents.ts
+++ b/frontend/src/sound/soundEvents.ts
@@ -2,14 +2,9 @@
  * UI sound events and preferences.
  * - Linux-focused: user selects an absolute sounds folder (default: /home/sounds).
  * - No bundled defaults. If folder/file is missing, sound simply won't play.
- *
  */
 
-export type SoundEventId =
-  | "buttonClick"
-  | "progressIncrement"
-  | "progressDecrement"
-  | "progressComplete";
+import type { SoundEventId } from "../../../types/shared";
 
 export interface SoundPreferences {
   /** Master volume 0..1 */
@@ -23,7 +18,6 @@ export interface SoundPreferences {
 }
 
 export const DEFAULT_SOUND_FILES: Record<SoundEventId, string> = {
-  buttonClick: "ui_click.mp3",
   progressIncrement: "ui_increment.mp3",
   progressDecrement: "ui_decrement.mp3",
   progressComplete: "ui_complete.mp3",

--- a/frontend/src/sound/soundEvents.ts
+++ b/frontend/src/sound/soundEvents.ts
@@ -1,7 +1,7 @@
 /**
  * UI sound events and preferences.
- * - Linux-focused: user selects an absolute sounds folder (default: /home/sounds).
- * - No bundled defaults. If folder/file is missing, sound simply won't play.
+ * - Canonical filenames only are stored in preferences; renderer reads raw bytes via IPC
+ *   and creates blob URLs at runtime for playback.
  */
 
 // TODO: Confusing file name + remove extra comments.
@@ -41,7 +41,6 @@ export const DEFAULT_SOUND_PREFERENCES: SoundPreferences = {
   masterVolume: DEFAULT_MASTER_VOLUME,
   muteAll: DEFAULT_MUTE_ALL,
   soundsFolder: DEFAULT_SOUNDS_FOLDER,
-  // Default to empty strings; renderer uses data URLs for playback.
   eventFiles: ((): Record<SoundEventId, string> => {
     const map: Record<SoundEventId, string> = {} as Record<
       SoundEventId,

--- a/frontend/src/sound/soundManager.ts
+++ b/frontend/src/sound/soundManager.ts
@@ -1,0 +1,327 @@
+import {
+  DEFAULT_SOUND_PREFERENCES,
+  DEFAULT_SOUND_FILES,
+  DEFAULT_SOUNDS_FOLDER,
+} from "./soundEvents";
+import type { SoundEventId, SoundPreferences } from "./soundEvents";
+
+// TODO: Sync the sound files to GDrive as well.
+
+/**
+ * Renderer-side sound manager responsible for:
+ * - Managing preferences (master volume, mute, event-to-file mapping)
+ * - Preloading base audio elements for events
+ * - Overlap-safe playback via cloning
+ * - Simple precedence: new sound interrupts the previous
+ */
+export class SoundManager {
+  private static singletonInstance: SoundManager | null = null;
+
+  private preferences: SoundPreferences;
+  private baseAudioElementsByEvent: Map<SoundEventId, HTMLAudioElement>;
+  private currentPlayingAudio: HTMLAudioElement | null;
+
+  /**
+   * Initialize with preferences and preload audio.
+   * @param initialPreferences Optional initial preferences.
+   */
+  private constructor(initialPreferences?: SoundPreferences) {
+    this.preferences = this.normalizePreferences(
+      typeof initialPreferences !== "undefined"
+        ? initialPreferences
+        : DEFAULT_SOUND_PREFERENCES
+    );
+
+    this.baseAudioElementsByEvent = new Map<SoundEventId, HTMLAudioElement>();
+    this.currentPlayingAudio = null;
+
+    this.preloadAllAudioElements();
+  }
+
+  /**
+   * Get the singleton instance; updates prefs if provided.
+   * @param initialPreferences Optional preferences to seed/update.
+   * @returns Singleton SoundManager.
+   */
+  public static getInstance(
+    initialPreferences?: SoundPreferences
+  ): SoundManager {
+    if (SoundManager.singletonInstance === null) {
+      SoundManager.singletonInstance = new SoundManager(initialPreferences);
+    } else {
+      if (typeof initialPreferences !== "undefined") {
+        SoundManager.singletonInstance.setPreferences(initialPreferences);
+      }
+    }
+
+    return SoundManager.singletonInstance;
+  }
+
+  /**
+   * Get a copy of the current preferences.
+   * @returns Copy of SoundPreferences.
+   */
+  public getPreferences(): SoundPreferences {
+    return {
+      masterVolume: this.preferences.masterVolume,
+      muteAll: this.preferences.muteAll,
+      soundsFolder: this.preferences.soundsFolder,
+      eventFiles: { ...this.preferences.eventFiles },
+    };
+  }
+
+  /**
+   * Replace preferences and reload audio.
+   * @param newPreferences New preferences.
+   */
+  public setPreferences(newPreferences: SoundPreferences): void {
+    this.preferences = this.normalizePreferences(newPreferences);
+    this.preloadAllAudioElements();
+  }
+
+  /**
+   * Set master volume (0..1).
+   * @param masterVolume 0..1 inclusive.
+   */
+  public setMasterVolume(masterVolume: number): void {
+    this.preferences.masterVolume = this.clampVolume(masterVolume);
+  }
+
+  /**
+   * Mute or unmute all sounds.
+   * @param muteAll True to mute all.
+   */
+  public setMuteAll(muteAll: boolean): void {
+    this.preferences.muteAll = muteAll === true;
+  }
+
+  /**
+   * Map an event to a sound file and preload.
+   * @param soundEventId Event id.
+   * @param fileUrl URL or path to audio.
+   */
+  public setSoundFileForEvent(
+    soundEventId: SoundEventId,
+    fileUrl: string
+  ): void {
+    this.preferences.eventFiles[soundEventId] = fileUrl;
+    this.preloadAudioElementForEvent(soundEventId);
+  }
+
+  /**
+   * Play a sound for an event, respecting mute. If another sound is playing,
+   * it is stopped so the new one takes precedence.
+   * @param soundEventId Event id.
+   */
+  public playEventSound(soundEventId: SoundEventId): void {
+    // Stop any currently playing sound to give precedence to the new one
+    if (this.currentPlayingAudio !== null) {
+      try {
+        this.currentPlayingAudio.pause();
+        this.currentPlayingAudio.currentTime = 0;
+      } catch {
+        // Ignore errors
+      }
+      this.currentPlayingAudio = null;
+    }
+
+    if (this.preferences.muteAll === true) {
+      return;
+    }
+
+    let baseAudioElement = this.baseAudioElementsByEvent.get(soundEventId);
+
+    if (typeof baseAudioElement === "undefined") {
+      this.preloadAudioElementForEvent(soundEventId);
+      baseAudioElement = this.baseAudioElementsByEvent.get(soundEventId);
+    }
+
+    if (typeof baseAudioElement === "undefined") {
+      // Could not create base element; nothing to play
+      return;
+    }
+
+    const clonedAudioElement = baseAudioElement.cloneNode(
+      true
+    ) as HTMLAudioElement;
+    clonedAudioElement.volume = this.preferences.masterVolume;
+
+    // Track as current; clear reference when done
+    this.currentPlayingAudio = clonedAudioElement;
+    const clearIfCurrent = () => {
+      if (this.currentPlayingAudio === clonedAudioElement) {
+        this.currentPlayingAudio = null;
+      }
+    };
+
+    clonedAudioElement.addEventListener("ended", clearIfCurrent, {
+      once: true,
+    });
+
+    clonedAudioElement.addEventListener("error", clearIfCurrent, {
+      once: true,
+    });
+
+    const playPromise = clonedAudioElement.play();
+
+    if (typeof playPromise?.catch === "function") {
+      playPromise.catch(() => {
+        // Ignore autoplay/gesture restrictions; actual click handlers will succeed
+      });
+    }
+  }
+
+  /**
+   * Merge input with defaults and clamp values.
+   * @param preferences Input preferences.
+   * @returns Normalized preferences.
+   */
+  private normalizePreferences(
+    preferences: SoundPreferences
+  ): SoundPreferences {
+    const normalizedMasterVolume = this.clampVolume(preferences.masterVolume);
+    const normalizedMuteAll = preferences.muteAll === true;
+    const normalizedSoundsFolder =
+      typeof preferences.soundsFolder === "string" &&
+      preferences.soundsFolder.length > 0
+        ? preferences.soundsFolder
+        : DEFAULT_SOUND_PREFERENCES.soundsFolder;
+    const normalizedEventFiles: Record<SoundEventId, string> = {
+      ...DEFAULT_SOUND_FILES,
+      ...preferences.eventFiles,
+    };
+
+    return {
+      masterVolume: normalizedMasterVolume,
+      muteAll: normalizedMuteAll,
+      soundsFolder: normalizedSoundsFolder,
+      eventFiles: normalizedEventFiles,
+    };
+  }
+
+  /**
+   * Clamp volume to [0, 1].
+   * @param volume Input volume.
+   * @returns Clamped volume.
+   */
+  private clampVolume(volume: number): number {
+    if (Number.isFinite(volume) === false) {
+      return DEFAULT_SOUND_PREFERENCES.masterVolume;
+    }
+
+    if (volume < 0) {
+      return 0;
+    }
+
+    if (volume > 1) {
+      return 1;
+    }
+
+    return volume;
+  }
+
+  /**
+   * Preload base audio for all events.
+   */
+  private preloadAllAudioElements(): void {
+    const soundEventIds = Object.keys(
+      this.preferences.eventFiles
+    ) as SoundEventId[];
+
+    for (const soundEventId of soundEventIds) {
+      this.preloadAudioElementForEvent(soundEventId);
+    }
+  }
+
+  /**
+   * Preload base audio element for an event.
+   * @param soundEventId Event id.
+   */
+  private preloadAudioElementForEvent(soundEventId: SoundEventId): void {
+    const ref = this.preferences.eventFiles[soundEventId];
+    if (typeof ref !== "string" || ref.length === 0) {
+      return;
+    }
+
+    const url = this.resolveToPlayableUrl(ref);
+    if (!url) {
+      return;
+    }
+
+    try {
+      const baseAudioElement = new Audio(url);
+      baseAudioElement.preload = "auto";
+      baseAudioElement.volume = 1.0;
+      this.baseAudioElementsByEvent.set(soundEventId, baseAudioElement);
+    } catch {
+      // Ignore invalid URLs
+    }
+  }
+
+  /**
+   * Convert a ref (URL, absolute path, or basename) to a file URL for Audio.
+   */
+  private resolveToPlayableUrl(ref: string): string | null {
+    // Already a URL
+    if (ref.includes("://")) {
+      return ref;
+    }
+
+    // Absolute Linux path
+    if (ref.startsWith("/")) {
+      return this.linuxPathToFileUrl(ref);
+    }
+
+    // Basename -> resolve against soundsFolder
+    const folder = this.preferences.soundsFolder || DEFAULT_SOUNDS_FOLDER;
+    const abs = this.joinLinux(folder, ref);
+
+    if (!abs.startsWith("/")) {
+      return null;
+    }
+
+    return this.linuxPathToFileUrl(abs);
+  }
+
+  /**
+   * Minimal Linux path join (renderer-safe).
+   */
+  private joinLinux(dir: string, name: string): string {
+    if (!dir) {
+      return name;
+    }
+
+    if (dir.endsWith("/")) {
+      return dir + name;
+    }
+
+    return `${dir}/${name}`;
+  }
+
+  /**
+   * Convert absolute Linux path to file:// URL with encoding.
+   */
+  private linuxPathToFileUrl(p: string): string {
+    // Ensure absolute
+    if (!p.startsWith("/")) {
+      return "";
+    }
+
+    const encoded = p
+      .split("/")
+      .map((seg) => encodeURIComponent(seg))
+      .join("/");
+    // Ensure exactly three slashes after file:
+    const stripped = encoded.startsWith("/") ? encoded.slice(1) : encoded;
+
+    return `file:///${stripped}`;
+  }
+}
+
+/**
+ * Convenience accessor for the singleton.
+ * @returns SoundManager instance.
+ */
+export function getSoundManager(): SoundManager {
+  return SoundManager.getInstance();
+}

--- a/frontend/src/sound/soundManager.ts
+++ b/frontend/src/sound/soundManager.ts
@@ -1,9 +1,5 @@
 import type { SoundEventId } from "../../../types/shared";
-import {
-  DEFAULT_SOUND_PREFERENCES,
-  DEFAULT_SOUND_FILES,
-  DEFAULT_SOUNDS_FOLDER,
-} from "./soundEvents";
+import { DEFAULT_SOUND_PREFERENCES, DEFAULT_SOUND_FILES } from "./soundEvents";
 import type { SoundPreferences } from "./soundEvents";
 
 // TODO: Sync the sound files to GDrive as well.
@@ -203,8 +199,8 @@ export class SoundManager {
         ? preferences.soundsFolder
         : DEFAULT_SOUND_PREFERENCES.soundsFolder;
     const normalizedEventFiles: Record<SoundEventId, string> = {
-      ...DEFAULT_SOUND_FILES,
-      ...preferences.eventFiles,
+      ...(DEFAULT_SOUND_PREFERENCES.eventFiles as Record<SoundEventId, string>),
+      ...(preferences.eventFiles as Record<SoundEventId, string>),
     };
 
     return {
@@ -278,30 +274,12 @@ export class SoundManager {
    * Convert a ref (URL, absolute path, or basename) to a file URL for Audio.
    */
   private resolveToPlayableUrl(ref: string): string | null {
-    // Already a URL
-    if (ref.includes("://")) {
+    // Only allow data URLs in the renderer to avoid file:// restrictions.
+    if (typeof ref === "string" && ref.startsWith("data:")) {
       return ref;
-    }
-
-    // Data URL (sandbox-safe)
-    if (ref.startsWith("data:")) {
-      return ref;
-    }
-
-    // Absolute Linux path
-    if (ref.startsWith("/")) {
-      return this.linuxPathToFileUrl(ref);
-    }
-
-    // Basename -> resolve against soundsFolder
-    const folder = this.preferences.soundsFolder || DEFAULT_SOUNDS_FOLDER;
-    const abs = this.joinLinux(folder, ref);
-
-    if (!abs.startsWith("/")) {
+    } else {
       return null;
     }
-
-    return this.linuxPathToFileUrl(abs);
   }
 
   /**

--- a/frontend/src/sound/soundManager.ts
+++ b/frontend/src/sound/soundManager.ts
@@ -1,9 +1,10 @@
+import type { SoundEventId } from "../../../types/shared";
 import {
   DEFAULT_SOUND_PREFERENCES,
   DEFAULT_SOUND_FILES,
   DEFAULT_SOUNDS_FOLDER,
 } from "./soundEvents";
-import type { SoundEventId, SoundPreferences } from "./soundEvents";
+import type { SoundPreferences } from "./soundEvents";
 
 // TODO: Sync the sound files to GDrive as well.
 

--- a/frontend/src/sound/soundManager.ts
+++ b/frontend/src/sound/soundManager.ts
@@ -173,6 +173,21 @@ export class SoundManager {
   }
 
   /**
+   * Stop any currently playing sound immediately.
+   */
+  public stopAll(): void {
+    if (this.currentPlayingAudio !== null) {
+      try {
+        this.currentPlayingAudio.pause();
+        this.currentPlayingAudio.currentTime = 0;
+      } catch {
+        // Ignore errors
+      }
+      this.currentPlayingAudio = null;
+    }
+  }
+
+  /**
    * Merge input with defaults and clamp values.
    * @param preferences Input preferences.
    * @returns Normalized preferences.

--- a/frontend/src/utils/crypto.ts
+++ b/frontend/src/utils/crypto.ts
@@ -42,6 +42,17 @@ export class CryptoError extends Error {
   }
 }
 
+// Convert a Uint8Array to base64 without overflowing the call stack.
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000; // 32KB chunks
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    const chunk = bytes.subarray(offset, offset + chunkSize);
+    binary += String.fromCharCode.apply(null, Array.from(chunk));
+  }
+  return btoa(binary);
+}
+
 export async function encryptData(
   data: string,
   password: string
@@ -60,11 +71,9 @@ export async function encryptData(
 
     // Save salt, iv, and encrypted data as base64 strings.
     const bundle = {
-      salt: btoa(String.fromCharCode(...new Uint8Array(salt))),
-      iv: btoa(String.fromCharCode(...new Uint8Array(iv))),
-      encryptedData: btoa(
-        String.fromCharCode(...new Uint8Array(encryptedData))
-      ),
+      salt: uint8ArrayToBase64(new Uint8Array(salt)),
+      iv: uint8ArrayToBase64(new Uint8Array(iv)),
+      encryptedData: uint8ArrayToBase64(new Uint8Array(encryptedData)),
     };
 
     return JSON.stringify(bundle);

--- a/frontend/src/utils/errorMapping.ts
+++ b/frontend/src/utils/errorMapping.ts
@@ -1,4 +1,4 @@
-// Helpers for working with IPC error envelopes
+// Helpers for working with IPC error wrappers
 
 export interface ErrorWrapper {
   code: string;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -4,7 +4,11 @@
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "noUnusedLocals": false,
-    "noUnusedParameters": false
+    "noUnusedParameters": false,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "references": [
     { "path": "./tsconfig.app.json" },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import vitePluginSvgr from "vite-plugin-svgr";
+import path from "node:path";
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -14,5 +15,10 @@ export default defineConfig({
   server: {
     host: true,
     port: 5173,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(process.cwd(), "src"),
+    },
   },
 });

--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, ipcMain, safeStorage, shell } from "electron";
 import path from "path";
 import fs from "fs";
-import { AppData, OAuthUser, ErrorCodes } from "./types/shared";
+import { AppData, OAuthUser, ErrorCodes, SoundEventId } from "./types/shared";
 import Store from "electron-store";
 import pkceChallenge from "pkce-challenge";
 import dotenv from "dotenv";
@@ -33,6 +33,8 @@ import {
   MainProcessError,
   SafeStorageError,
 } from "./utils/main-process-errors";
+
+// TODO: Will need to split this into multiple files, I can't tell what's going on anymore.
 
 dotenv.config();
 
@@ -432,6 +434,50 @@ function setupDriveIpc() {
   });
 }
 
+/** Canonical file names for .mp3 sounds per event. */
+const SOUND_FILE_NAMES: Record<SoundEventId, string> = {
+  progressIncrement: "ui_increment.mp3",
+  progressDecrement: "ui_decrement.mp3",
+  progressComplete: "ui_complete.mp3",
+};
+
+/** Ensure a directory exists, creating parents as needed. */
+function ensureDirSync(dir: string): void {
+  if (fs.existsSync(dir) === false) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+/** Resolve the sounds folder under userData. */
+function getSoundsDir(): string {
+  return path.join(app.getPath("userData"), "sounds");
+}
+
+// Save a user-uploaded .mp3 sound under a canonical filename for the event.
+handleInvoke(
+  "sounds-save",
+  async (eventId: SoundEventId, content: Uint8Array) => {
+    const name = SOUND_FILE_NAMES[eventId];
+    if (typeof name !== "string") {
+      throw new UnknownMainProcessError("Invalid sound event id");
+    }
+
+    const dir = getSoundsDir();
+    ensureDirSync(dir);
+
+    const filePath = path.join(dir, name);
+
+    try {
+      const buffer = Buffer.from(content);
+      fs.writeFileSync(filePath, buffer);
+    } catch (error) {
+      throw new UnknownMainProcessError(
+        `Failed to save sound for ${String(eventId)}`
+      );
+    }
+  }
+);
+
 // Listener to handle saving progress bar data.
 // TODO: Group-up related handlers, as above.
 handleInvoke("save-data", async (data: AppData) => {
@@ -459,9 +505,26 @@ handleInvoke("save-data", async (data: AppData) => {
     }
   }
 
+  // If sounds is not provided, preserve existing sounds on disk.
+  let soundsToPersist = data.sounds;
+  if (typeof soundsToPersist === "undefined") {
+    if (fs.existsSync(filePath)) {
+      try {
+        const existingJson = fs.readFileSync(filePath, "utf-8");
+        const existingAppData = JSON.parse(existingJson) as AppData;
+        if (existingAppData && typeof existingAppData.sounds !== "undefined") {
+          soundsToPersist = existingAppData.sounds;
+        }
+      } catch (error) {
+        // Ignore parse errors; fall back to undefined.
+      }
+    }
+  }
+
   const dataToSave: AppData = {
     bars: Array.isArray(data.bars) ? data.bars : [],
     lastSynced: lastSyncedToPersist,
+    sounds: soundsToPersist,
   };
 
   fs.writeFileSync(filePath, JSON.stringify(dataToSave, null, 2), "utf-8");
@@ -482,7 +545,7 @@ handleInvoke("load-data", async () => {
     console.error("Error loading data: ", error);
   }
 
-  return { bars: [], lastSynced: null } as AppData;
+  return { bars: [], lastSynced: null, sounds: undefined } as AppData;
 });
 
 // Handle window controls.

--- a/main.ts
+++ b/main.ts
@@ -478,6 +478,30 @@ handleInvoke(
   }
 );
 
+// Read the saved .mp3 bytes for a given event, or null if not found.
+handleInvoke(
+  "sounds-read",
+  async (eventId: SoundEventId): Promise<Uint8Array | null> => {
+    const name = SOUND_FILE_NAMES[eventId];
+    if (typeof name !== "string") {
+      throw new UnknownMainProcessError("Invalid sound event id");
+    }
+
+    const dir = getSoundsDir();
+    const filePath = path.join(dir, name);
+
+    try {
+      if (fs.existsSync(filePath) === false) {
+        return null;
+      }
+      const buffer = fs.readFileSync(filePath);
+      return new Uint8Array(buffer);
+    } catch (error) {
+      return null;
+    }
+  }
+);
+
 // Listener to handle saving progress bar data.
 // TODO: Group-up related handlers, as above.
 handleInvoke("save-data", async (data: AppData) => {

--- a/preload.ts
+++ b/preload.ts
@@ -71,6 +71,9 @@ const api: IElectronAPI = {
   /** Save a user-uploaded .mp3 sound under a canonical filename for the event. */
   saveSoundForEvent: (eventId, content) =>
     invokeAndUnwrap<void>("sounds-save", eventId, content),
+  /** Read raw .mp3 bytes for a given event from disk. */
+  readSoundForEvent: (eventId) =>
+    invokeAndUnwrap<Uint8Array | null>("sounds-read", eventId),
 };
 
 // Expose the API to the renderer process

--- a/preload.ts
+++ b/preload.ts
@@ -47,6 +47,8 @@ const api: IElectronAPI = {
     };
   },
   saveData: (data: AppData) => invokeAndUnwrap<SaveResult>("save-data", data),
+  savePartialData: (data: Partial<AppData>) =>
+    invokeAndUnwrap<SaveResult>("save-partial-data", data),
   loadData: () => invokeAndUnwrap<AppData | null>("load-data"),
   savePassword: (password: string) =>
     invokeAndUnwrap<void>("save-password", password),

--- a/preload.ts
+++ b/preload.ts
@@ -8,7 +8,7 @@ import { AuthStatus } from "./types/shared";
 import type { IpcResult } from "./types/electron";
 import type { AppData, SaveResult } from "./types/shared";
 
-// Helper: invoke IPC channel and unwrap the standard IpcResult envelope
+// Helper: invoke IPC channel and unwrap the standard IpcResult wrapper
 async function invokeAndUnwrap<T>(channel: string, ...args: any[]): Promise<T> {
   const result = (await ipcRenderer.invoke(channel, ...args)) as IpcResult<T>;
 
@@ -22,7 +22,7 @@ async function invokeAndUnwrap<T>(channel: string, ...args: any[]): Promise<T> {
     return (result.data as T) ?? (undefined as unknown as T);
   }
 
-  // Error path: forward minimal error envelope { code, message, status }
+  // Error path: forward minimal error wrapper { code, message, status }
   throw result.error;
 }
 
@@ -65,6 +65,10 @@ const api: IElectronAPI = {
   driveRestore: (params: DriveRestoreParameters) =>
     invokeAndUnwrap<Uint8Array>("drive-restore", params),
   driveCancel: () => invokeAndUnwrap<void>("drive-cancel"),
+
+  /** Save a user-uploaded .mp3 sound under a canonical filename for the event. */
+  saveSoundForEvent: (eventId, content) =>
+    invokeAndUnwrap<void>("sounds-save", eventId, content),
 };
 
 // Expose the API to the renderer process

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -1,4 +1,4 @@
-import { AppData, AuthStatus, SaveResult } from "./shared";
+import { AppData, AuthStatus, SaveResult, SoundEventId } from "./shared";
 
 // Parameters for Google Drive IPC methods
 export type DriveSyncParameters = {
@@ -51,6 +51,12 @@ export interface IElectronAPI {
   driveSync: (params: DriveSyncParameters) => Promise<void>;
   driveRestore: (params: DriveRestoreParameters) => Promise<Uint8Array>;
   driveCancel: () => Promise<void>;
+
+  /** Save an uploaded .mp3 sound for the given event under a canonical filename. */
+  saveSoundForEvent: (
+    eventId: SoundEventId,
+    content: Uint8Array
+  ) => Promise<void>;
 }
 
 interface Window {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -62,6 +62,9 @@ export interface IElectronAPI {
     eventId: SoundEventId,
     content: Uint8Array
   ) => Promise<void>;
+
+  /** Read raw .mp3 bytes for the given sound event from local disk. Returns null if missing. */
+  readSoundForEvent: (eventId: SoundEventId) => Promise<Uint8Array | null>;
 }
 
 interface Window {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -34,6 +34,11 @@ export interface IElectronAPI {
 
   // Saving data locally.
   saveData: (data: AppData) => Promise<SaveResult>;
+  /**
+   * Save a partial subset of AppData fields, preserving unspecified fields on disk.
+   * Useful for modular settings updates (e.g., sounds) without passing all bars.
+   */
+  savePartialData: (data: Partial<AppData>) => Promise<SaveResult>;
   loadData: () => Promise<AppData | null>;
 
   // Encryption password management.

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -66,7 +66,8 @@ export type SoundEventId =
 
 /**
  * Preferences for UI sounds persisted in app data.
- * eventFiles contain data: URLs for sandbox-safe playback and sync.
+ * eventFiles contain canonical filenames per event (e.g., ui_increment.mp3) or an empty string if unset.
+ * No base64/data URLs are stored in app data.
  */
 export interface SoundsData {
   preferences: {

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -18,6 +18,7 @@ export interface VersionedAppData {
 export interface AppData {
   bars: ProgressBarData[];
   lastSynced?: string | null;
+  sounds?: SoundsData;
 }
 
 export interface SaveResult {
@@ -42,7 +43,7 @@ export interface AuthStatus {
   user: OAuthUser | null;
 }
 
-// Shared error codes (used by main <-> preload <-> renderer envelopes)
+// Shared error codes (used by main <-> preload <-> renderer wrappers)
 export const ErrorCodes = {
   Canceled: "Canceled",
   NotAuthenticated: "NotAuthenticated",
@@ -55,3 +56,21 @@ export const ErrorCodes = {
   SafeStorage: "SafeStorage",
   Unknown: "Unknown",
 } as const;
+
+/** Canonical UI sound events. */
+export type SoundEventId =
+  | "progressIncrement"
+  | "progressDecrement"
+  | "progressComplete";
+
+/**
+ * Preferences for UI sounds persisted in app data.
+ * eventFiles contain data: URLs for sandbox-safe playback and sync.
+ */
+export interface SoundsData {
+  preferences: {
+    masterVolume: number;
+    muteAll: boolean;
+    eventFiles: Record<SoundEventId, string>;
+  };
+}

--- a/types/shared.ts
+++ b/types/shared.ts
@@ -13,6 +13,7 @@ export interface VersionedAppData {
   version: number;
   lastSynced: string;
   bars: ProgressBarData[];
+  sounds?: SoundsData;
 }
 
 export interface AppData {


### PR DESCRIPTION
Sound-related changes:
- Adds sounds for increment, decrement and progress bar completion.
- Saves the sounds locally and also syncs them to Google Drive (in both cases unencrypted).
- Only accepting .mp3 files currently.

Other general changes:
- Add a settings menu, move the cloud modal inside of it.
- Add an entry + modal for the sounds, which allows the user to upload the custom sounds they want and control the master volume.


Fixes #2 
Fixes #33 
Fixes #36 